### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -39,11 +39,11 @@ setContrast	KEYWORD2
 setAddress	KEYWORD2
 command	KEYWORD2
 specialCommand	KEYWORD2
-enableSystemMessages    KEYWORD2
-disableSystemMessages    KEYWORD2
-enableSplash    KEYWORD2
-disableSplash    KEYWORD2
-saveSplash    KEYWORD2
+enableSystemMessages	KEYWORD2
+disableSystemMessages	KEYWORD2
+enableSplash	KEYWORD2
+disableSplash	KEYWORD2
+saveSplash	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords