### PR TITLE
Explicitly cast numeric literals to type byte to avoid ESP32 and ESP8266 compile errors

### DIFF
--- a/src/SerLCD.cpp
+++ b/src/SerLCD.cpp
@@ -344,8 +344,9 @@ void SerLCD::setCursor(byte col, byte row)
   int row_offsets[] = {0x00, 0x40, 0x14, 0x54};
 
   //kepp variables in bounds
-  row = max(0, row);            //row cannot be less than 0
-  row = min(row, MAX_ROWS - 1); //row cannot be greater than max rows
+  //Explicitly cast numeric literals to type byte to avoid ESP32 and ESP8266 compile errors
+  row = max((byte) 0, row);            //row cannot be less than 0
+  row = min(row, (byte)(MAX_ROWS - 1)); //row cannot be greater than max rows
 
   //send the command
   specialCommand(LCD_SETDDRAMADDR | (col + row_offsets[row]));


### PR DESCRIPTION
*** This is the correct pull request to merge.  It only changes one file with the fixed lines. ***

This is a fix for issue #6. The ESP32 and ESP8266 code uses templates to define the min/max function. This causes a compile error because the numerical literals are of implicit type (int) being compared to a byte parameter.

Even though the types are compatible, this type mismatch causes a compile error in the template used to define the min/max function in the ESP32 and ESP8266 code.

This fix explicitly casts the numeric literals in min() and max() to type (byte) and eliminate the compile error.