### PR TITLE
Explicitly cast numeric literals to type byte to avoid ESP32 and ESP8266 compile errors

### DIFF
--- a/src/SerLCD.cpp
+++ b/src/SerLCD.cpp
@@ -344,8 +344,9 @@ void SerLCD::setCursor(byte col, byte row)
   int row_offsets[] = {0x00, 0x40, 0x14, 0x54};
 
   //kepp variables in bounds
-  row = max(0, row);            //row cannot be less than 0
-  row = min(row, MAX_ROWS - 1); //row cannot be greater than max rows
+  //Explicitly cast numeric literals to type byte to avoid ESP32 and ESP8266 compile errors
+  row = max((byte) 0, row);            //row cannot be less than 0
+  row = min(row, (byte)(MAX_ROWS - 1)); //row cannot be greater than max rows
 
   //send the command
   specialCommand(LCD_SETDDRAMADDR | (col + row_offsets[row]));

--- a/src/SerLCD.cpp
+++ b/src/SerLCD.cpp
@@ -4,6 +4,7 @@
  *
  * By: Gaston R. Williams
  * Date: August 22, 2018
+ * Update: March 23, 2020 - fixed missing return value in write(uint8_t)
  *
  * License: This code is public domain but you buy me a beer if you use this and we meet someday (Beerware license).
  *
@@ -392,6 +393,7 @@ size_t SerLCD::write(uint8_t b)
   transmit(b);
   endTransmission(); //Stop transmission
   delay(10);         // wait a bit
+  return 1;
 } // write
 
 /*

--- a/src/SerLCD.cpp
+++ b/src/SerLCD.cpp
@@ -337,7 +337,6 @@ void SerLCD::home()
  * column - byte 0 to 19
  * row - byte 0 to 3
  *
- * returns: boolean true if cursor set.
  */
 void SerLCD::setCursor(byte col, byte row)
 {


### PR DESCRIPTION
*** This is the correct pull request to merge. It only changes one file with the fixed lines.***
*** An incorrect comment line is also moved. ***

This is a fix for issue #6. The ESP32 and ESP8266 code uses templates to define the min/max function. This causes a compile error because the numerical literals are of implicit type (int) being compared to a byte parameter.

Even though the types are compatible, this type mismatch causes a compile error in the template used to define the min/max function in the ESP32 and ESP8266 code.

This fix explicitly casts the numeric literals in min() and max() to type (byte) and eliminate the compile error.  The incorrect comment is removed.