### PR TITLE
Fix compiler warning from setCursor

### DIFF
--- a/src/SerLCD.cpp
+++ b/src/SerLCD.cpp
@@ -343,8 +343,6 @@ void SerLCD::setCursor(byte col, byte row)
   int row_offsets[] = {0x00, 0x40, 0x14, 0x54};
 
   //kepp variables in bounds
-  //Explicitly cast numeric literals to type byte to avoid ESP32 and ESP8266 compile errors
-  row = max((byte) 0, row);            //row cannot be less than 0
   row = min(row, (byte)(MAX_ROWS - 1)); //row cannot be greater than max rows
 
   //send the command


### PR DESCRIPTION
I've been working on a project that uses this library and figured I could give back to the community by fixing this compiler warning. On line 347 the max function is used to set a lower limit, but the input data is of type byte. In the arduino environment byte equates to uint8_t and so can never be less than 0 and thus causes a compiler warning.